### PR TITLE
Add bound on torch version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setuptools.setup(
     install_requires=[
         'requests',
         'flair>=0.4.3,!=0.4.4',
+        'torch>=1.1.0,<1.4.0'
         'spacy>=2.2.1',
         'tqdm>=4.29',
         'deduce>=1.0.2',


### PR DESCRIPTION
For the time being, the torch version is bound to `>=1.1.0,<1.4.0`.

With the new torch version `1.4.0`, pre-trained Flair models could not be loaded anymore. When loading, the following error occurred:

```
Traceback (most recent call last):
  File "demo.py", line 24, in <module>
    tagger = FlairTagger(model=model, tokenizer=tokenizer, verbose=False)
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/deidentify/taggers/flair_tagger.py", line 21, in __init__
    self.tagger = SequenceTagger.load(model_file)
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/flair/nn.py", line 103, in load
    model = cls._init_model_with_state_dict(state)
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/flair/models/sequence_tagger_model.py", line 244, in _init_model_with_state_dict
    train_initial_hidden_state=train_initial_hidden_state,
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/flair/models/sequence_tagger_model.py", line 198, in __init__
    self.to(flair.device)
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/torch/nn/modules/module.py", line 425, in to
    return self._apply(convert)
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/torch/nn/modules/module.py", line 201, in _apply
    module._apply(fn)
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/torch/nn/modules/module.py", line 201, in _apply
    module._apply(fn)
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/torch/nn/modules/module.py", line 201, in _apply
    module._apply(fn)
  [Previous line repeated 1 more time]
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/torch/nn/modules/rnn.py", line 137, in _apply
    self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names]
  File "/Users/jan.trienes/Desktop/tmp/venv/lib/python3.7/site-packages/torch/nn/modules/module.py", line 576, in __getattr__
    type(self).__name__, name))
AttributeError: 'LSTM' object has no attribute '_flat_weights_names'
```