### PR TITLE
Pin torch version in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
     - sklearn-crfsuite==0.3.6
     - flair==0.4.3
     - requests==2.22.0
+    - torch==1.3.1


### PR DESCRIPTION
This PR aligns `environment.yml` with `setup.py` with respect to the PyTorch constraint (see https://github.com/nedap/deidentify/pull/10). At some point, we can upgrade to a newer Flair version which solves this problem for us.