### PR TITLE
Fix BiLSTM-CRF with consecutive whitespace tokens

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     python_requires='>=3.7',
     install_requires=[
         'requests',
-        'flair>=0.4.3,!=0.4.4',
+        'flair>=0.4.3,!=0.4.4,<0.5',
         'torch>=1.1.0,<1.4.0',
         'spacy>=2.2.1',
         'tqdm>=4.29',


### PR DESCRIPTION
Flair 0.5 started to discard whitespace-only tokens. This breaks the `standoff - BIO - standoff` roundtrip. A temporary fix is to pin flair to `flair<0.5`.

### Testing done

```py
import flair

from deidentify.taggers import FlairTagger
from deidentify.tokenizer import TokenizerFactory
from deidentify.base import Document

tagger = FlairTagger(
    model='model_bilstmcrf_ons_large-v0.1.0',
    tokenizer=TokenizerFactory().tokenizer(corpus='ons', disable=("tagger", "ner")),
    verbose=False
)
 
doc = Document(
    name='doc_01',
    text='Mw geniet zichtbaar.  Maarten is de afgelopen periode veelal afwezig.'
)


print(f'flair.__version__: {flair.__version__}')
print(tagger.annotate([doc])[0].annotations)
```

With most recent flair:

```py
flair.__version__: 0.5.1
[Annotation(text=' ', start=21, end=22, tag='Name', doc_id='', ann_id='T0')]
```

With `flair==0.4.5`:

```py
flair.__version__: 0.4.5
[Annotation(text='Maarten', start=22, end=29, tag='Name', doc_id='', ann_id='T0')]
```

