### PR TITLE
Add utility API to generate surrogates for a set of annotated documents

### DIFF
--- a/deidentify/util/__init__.py
+++ b/deidentify/util/__init__.py
@@ -1,1 +1,1 @@
-from .replace_phi import mask_annotations
+from .replace_phi import mask_annotations, surrogate_annotations

--- a/deidentify/util/replace_phi.py
+++ b/deidentify/util/replace_phi.py
@@ -4,6 +4,7 @@ from deidentify.base import Annotation, Document
 from deidentify.surrogates.dataset_deidentifier import DatasetDeidentifier
 from deidentify.surrogates.dataset_deidentifier import Document as SurrogateDocument
 from deidentify.surrogates.rewrite_dataset import apply_surrogates
+from deidentify.surrogates.generators import RandomData
 
 
 def _uppercase_formatter(annotation: Annotation):
@@ -57,8 +58,9 @@ def mask_annotations(document: Document,
     return Document(name=document.name, text=text_rewritten, annotations=annotations_rewritten)
 
 
-def surrogate_annotations(docs: List[Document]) -> List[Document]:
-    dataset_deidentifier = DatasetDeidentifier()
+def surrogate_annotations(docs: List[Document], seed=42) -> List[Document]:
+    random_data = RandomData(seed=seed)
+    dataset_deidentifier = DatasetDeidentifier(random_data=random_data)
 
     surrogate_docs = [SurrogateDocument(doc.annotations, doc.text) for doc in docs]
     surrogate_docs = dataset_deidentifier.generate_surrogates(documents=surrogate_docs)

--- a/deidentify/util/replace_phi.py
+++ b/deidentify/util/replace_phi.py
@@ -1,6 +1,9 @@
-from typing import Callable
+from typing import Callable, List
 
 from deidentify.base import Annotation, Document
+from deidentify.surrogates.dataset_deidentifier import DatasetDeidentifier
+from deidentify.surrogates.dataset_deidentifier import Document as SurrogateDocument
+from deidentify.surrogates.rewrite_dataset import apply_surrogates
 
 
 def _uppercase_formatter(annotation: Annotation):
@@ -52,3 +55,15 @@ def mask_annotations(document: Document,
 
     text_rewritten += document.text[original_text_pointer:]
     return Document(name=document.name, text=text_rewritten, annotations=annotations_rewritten)
+
+
+def surrogate_annotations(docs: List[Document]) -> List[Document]:
+    dataset_deidentifier = DatasetDeidentifier()
+
+    surrogate_docs = [SurrogateDocument(doc.annotations, doc.text) for doc in docs]
+    surrogate_docs = dataset_deidentifier.generate_surrogates(documents=surrogate_docs)
+
+    for doc in surrogate_docs:
+        annotations, surrogates = doc.annotation_surrogate_pairs()
+        rewritten_text, rewritten_annotations = apply_surrogates(doc.text, annotations, surrogates)
+        yield Document(name='', text=rewritten_text, annotations=rewritten_annotations)

--- a/tests/util/test_replace_phi.py
+++ b/tests/util/test_replace_phi.py
@@ -1,5 +1,7 @@
+import re
+
 from deidentify.base import Annotation, Document
-from deidentify.util import mask_annotations
+from deidentify.util import mask_annotations, surrogate_annotations
 
 
 def test_mask_annotations():
@@ -19,3 +21,21 @@ def test_mask_annotations():
         Annotation(text='[EMAIL]', start=22, end=29, tag='Email', doc_id='', ann_id='T1'),
         Annotation(text='[PHONE_FAX]', start=34, end=45, tag='Phone_fax', doc_id='', ann_id='T2')
     ]
+
+
+def test_surrogate_annotations():
+    text = "De patient J. Jansen (e: j.jnsen@email.com, t: 06-12345678)"
+    annotations = [
+        Annotation(text='J. Jansen', start=11, end=20, tag='Name', doc_id='', ann_id='T0'),
+        Annotation(text='j.jnsen@email.com', start=25, end=42, tag='Email', doc_id='', ann_id='T1'),
+        Annotation(text='06-12345678', start=47, end=58, tag='Phone_fax', doc_id='', ann_id='T2')
+    ]
+    doc = Document(name='test_doc', text=text, annotations=annotations)
+
+    surrogate_doc = list(surrogate_annotations([doc]))[0]
+
+    assert len(surrogate_doc.annotations) == len(doc.annotations)
+    assert re.match(r'De patient .* \(e: .*, t: .*\)', doc.text)
+
+    for ann in surrogate_doc.annotations:
+        assert surrogate_doc.text[ann.start:ann.end] == ann.text


### PR DESCRIPTION
The utility function is a wrapper around the `deidentify.surrogates` module. It is likely that this API will change in future.