### PR TITLE
Add dateinfer and nameparser to setup.py

### DIFF
--- a/deidentify/surrogates/generators/date.py
+++ b/deidentify/surrogates/generators/date.py
@@ -3,7 +3,7 @@ import locale
 import re
 from datetime import datetime
 
-import dateinfer
+import pydateinfer as dateinfer
 from dateutil.relativedelta import relativedelta
 from loguru import logger
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
     - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.0/en_core_web_sm-2.2.0.tar.gz#egg=en_core_web_sm==2.2.0
     - https://github.com/explosion/spacy-models/releases/download/nl_core_news_sm-2.2.1/nl_core_news_sm-2.2.1.tar.gz#egg=nl_core_news_sm==2.2.1
     - deduce==1.0.2
-    - git+https://github.com/nedap/dateinfer.git@071400be9e3554d5c1871c53c516ed9523f7e6e4#egg=pydateinfer
+    - py-dateinfer==0.4.5
     - loguru==0.4.0
     - nameparser==1.0.2
     - sklearn-crfsuite==0.3.6

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,9 @@ setuptools.setup(
         'loguru>=0.2.5',
         'sklearn-crfsuite>=0.3.6',
         'unidecode>=1.0.23',
-        'pandas>=0.23.4'
+        'pandas>=0.23.4',
+        'nameparser>=1.0',
+        'py-dateinfer>=0.4.5'
     ],
     cmdclass={
         'verify': VerifyVersionCommand,

--- a/tests/surrogates/generators/test_date.py
+++ b/tests/surrogates/generators/test_date.py
@@ -294,7 +294,7 @@ def test_date_surrogate_generator_all_unanchored():
 
 
 def test_switch_locale():
-    import dateinfer
+    import pydateinfer as dateinfer
     import locale
 
     locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')


### PR DESCRIPTION
Adds dateinfer and nameparser install dependencies to setup.py. This is needed for #21.

Also migrates from [nedap/dateinfer](https://github.com/nedap/dateinfer) to a recent release of it on pypi ([`py-dateinfer`](https://pypi.org/project/py-dateinfer/)).