### PR TITLE
Fix whitespace token issue with newer flair versions

### DIFF
--- a/deidentify/methods/bilstmcrf/flair_utils.py
+++ b/deidentify/methods/bilstmcrf/flair_utils.py
@@ -60,7 +60,13 @@ def standoff_to_flair_sents(docs: List[Document],
     for sent in sents:
         flair_sent = Sentence()
         for token in sent:
-            tok = Token(token.text)
+            if token.text.isspace():
+                # spaCy preserves consecutive whitespaces, while flair ignores them.
+                # This would make a round-trip standoff -> token -> standoff impossible.
+                # To accommodate whitespace tokens with flair, we add a special token.
+                tok = Token('<SPACE>')
+            else:
+                tok = Token(token.text)
             tok.add_tag(tag_type='ner', tag_value=token.label)
             flair_sent.add_token(tok)
         flair_sents.append(flair_sent)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     python_requires='>=3.7',
     install_requires=[
         'requests',
-        'flair>=0.4.3,!=0.4.4,<0.5',
+        'flair>=0.4.3',
         'torch>=1.1.0,<1.4.0',
         'spacy>=2.2.1',
         'tqdm>=4.29',

--- a/tests/methods/test_flair_utils.py
+++ b/tests/methods/test_flair_utils.py
@@ -25,11 +25,11 @@ def test_standoff_to_flair_sents():
         '<',
         't.njg.nmmeso@rcrmb.nl',
         '>',
-        '\n',
+        '<SPACE>',
         '07',
         'apr',
         '.',
-        '\n\n',
+        '<SPACE>',
     ]
 
     assert bio_tags == [
@@ -108,7 +108,7 @@ def test_flair_sentence_with_whitespace_tokens():
     # spaCy adds consecutive whitespace tokens as a single whitespace. These should be retained
     # in the Flair sentence, otherwise it's not possible to reconstruct the original document from
     # the tokenized representation.
-    assert [token.text for token in flair_sents[0]] == ['Mw', 'geniet', 'zichtbaar', '.', ' ']
+    assert [token.text for token in flair_sents[0]] == ['Mw', 'geniet', 'zichtbaar', '.', '<SPACE>']
 
     spacy_doc = docs[0].spacy_doc
     spacy_sents = list(spacy_doc.sents)


### PR DESCRIPTION
With flair>=0.5, whitespace tokens are ignored when constructing sentences ([flair code](https://github.com/flairNLP/flair/blob/v0.5/flair/data.py#L516)).

To make round-trips from standoff -> token -> standoff possible, those tokens need to be retained. As a fix, we previously added an upper bound on the flair version (#20). However, this prevents us from upgrading to newer flair versions.

In this PR, we update sentence construction such that whitespace-only tokens are replaced with a special token.
Furthermore, the upper bound on the flair version can now be removed.