### PR TITLE
Bundle generator resources with python package via package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,13 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/nedap/deidentify",
     packages=setuptools.find_packages(exclude=['tests', 'tests.*']),
-    package_data={'': ['LICENSE']},
+    package_data={
+        '': ['LICENSE'],
+        'deidentify': [
+            'surrogates/generators/resources/*.csv',
+            'surrogates/generators/resources/*.txt'
+        ]
+    },
     license="MIT License",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
An import like `from deidentify.util import mask_annotations` would cause a `FileNotFoundError` on `deidentify/surrogates/generators/resources/*` because the generator assets were excluded from the PyPI package bundle.

This PR fixes the issue.

cc @AIessa 