### PR TITLE
Add customizable error handling for PHI replacement

### DIFF
--- a/deidentify/surrogates/rewrite_dataset.py
+++ b/deidentify/surrogates/rewrite_dataset.py
@@ -7,7 +7,7 @@ from os.path import basename, join, splitext
 import pandas as pd
 from loguru import logger
 
-from deidentify.base import Annotation
+from deidentify.base import Annotation, Document
 from deidentify.dataset.brat import load_brat_text, write_brat_document
 
 
@@ -41,7 +41,7 @@ def apply_surrogates(text, annotations, surrogates):
         original_text_pointer = annotation.end
 
     text_rewritten += text[original_text_pointer:]
-    return text_rewritten, adjusted_annotations
+    return Document(name='', text=text_rewritten, annotations=adjusted_annotations)
 
 
 def main(args):
@@ -65,11 +65,13 @@ def main(args):
         ), axis=1)
 
         surrogates = rows.surrogate.values
-
-        text_rewritten, adjusted_annotations = apply_surrogates(text, annotations, surrogates)
-
-        write_brat_document(args.output_path, doc_id,
-                            text=text_rewritten, annotations=adjusted_annotations)
+        surrogate_doc = apply_surrogates(text, annotations, surrogates)
+        write_brat_document(
+            args.output_path,
+            doc_id,
+            text=surrogate_doc.text,
+            annotations=surrogate_doc.annotations
+        )
 
     files_with_annotations = set(df_surrogates.doc_id.values)
     all_files = [splitext(basename(f))[0] for f in glob.glob(join(args.data_path, '*.txt'))]

--- a/deidentify/surrogates/rewrite_dataset.py
+++ b/deidentify/surrogates/rewrite_dataset.py
@@ -17,7 +17,6 @@ def apply_surrogates(text, annotations, surrogates, errors='raise'):
     # Positive shift if surrogates are longer than original annotations
     # Negative shift if surrogates are shorter
     shift = 0
-
     original_text_pointer = 0
     text_rewritten = ''
 
@@ -27,7 +26,6 @@ def apply_surrogates(text, annotations, surrogates, errors='raise'):
         if not surrogate:
             if errors == 'raise':
                 raise ValueError(f'No valid surrogate for {annotation}')
-
             if errors == 'skip':
                 surrogate = annotation.text
             elif errors == 'coerce':

--- a/deidentify/surrogates/rewrite_dataset.py
+++ b/deidentify/surrogates/rewrite_dataset.py
@@ -26,7 +26,7 @@ def apply_surrogates(text, annotations, surrogates, errors='raise'):
         if not surrogate:
             if errors == 'raise':
                 raise ValueError(f'No valid surrogate for {annotation}')
-            if errors == 'skip':
+            if errors == 'ignore':
                 surrogate = annotation.text
             elif errors == 'coerce':
                 surrogate = f'[{annotation.tag}]'

--- a/deidentify/util/replace_phi.py
+++ b/deidentify/util/replace_phi.py
@@ -66,16 +66,18 @@ def surrogate_annotations(docs: List[Document], seed=42, errors='raise') -> List
     seed : int
         Set this seed to make the random generation deterministic.
     errors : str {'ignore', 'raise', 'coerce'}, default 'raise'
-        - If 'raise', then errors during surrogate generation will raise an exception.
-        - If 'ignore', then failing annotations are skipped (they and PHI remains in text)
-        - If 'coerce', then failing annotations are replaced with a placeholder of form `[annotation.tag]`
+        - If 'raise',  errors during surrogate generation will raise an exception.
+        - If 'ignore', failing annotations are skipped (they and PHI remains in text)
+        - If 'coerce', failing annotations are replaced with pattern `[annotation.tag]`
 
     Returns
     -------
     List[Document]
         A copy of `docs` with with text and annotations rewritten to their surrogates.
 
-        If errors is 'ignore' or 'coerce', an extra property of type List is added to the returned documents (`Document.annotations_without_surrogates`), which includes annotations of the *input document* that could not be replaced with a surrogate.
+        If errors is 'ignore' or 'coerce', an extra property of type List is added to the returned
+        documents (`Document.annotations_without_surrogates`), which includes annotations of the
+        *input document* that could not be replaced with a surrogate.
 
     """
     random_data = RandomData(seed=seed)

--- a/deidentify/util/replace_phi.py
+++ b/deidentify/util/replace_phi.py
@@ -58,7 +58,7 @@ def mask_annotations(document: Document,
     return Document(name=document.name, text=text_rewritten, annotations=annotations_rewritten)
 
 
-def surrogate_annotations(docs: List[Document], seed=42) -> List[Document]:
+def surrogate_annotations(docs: List[Document], seed=42, errors='raise') -> List[Document]:
     random_data = RandomData(seed=seed)
     dataset_deidentifier = DatasetDeidentifier(random_data=random_data)
 
@@ -67,5 +67,5 @@ def surrogate_annotations(docs: List[Document], seed=42) -> List[Document]:
 
     for doc in surrogate_docs:
         annotations, surrogates = doc.annotation_surrogate_pairs()
-        doc_rewritten = apply_surrogates(doc.text, annotations, surrogates)
+        doc_rewritten = apply_surrogates(doc.text, annotations, surrogates, errors=errors)
         yield doc_rewritten

--- a/deidentify/util/replace_phi.py
+++ b/deidentify/util/replace_phi.py
@@ -67,5 +67,5 @@ def surrogate_annotations(docs: List[Document], seed=42) -> List[Document]:
 
     for doc in surrogate_docs:
         annotations, surrogates = doc.annotation_surrogate_pairs()
-        rewritten_text, rewritten_annotations = apply_surrogates(doc.text, annotations, surrogates)
-        yield Document(name='', text=rewritten_text, annotations=rewritten_annotations)
+        doc_rewritten = apply_surrogates(doc.text, annotations, surrogates)
+        yield doc_rewritten

--- a/deidentify/util/replace_phi.py
+++ b/deidentify/util/replace_phi.py
@@ -59,6 +59,25 @@ def mask_annotations(document: Document,
 
 
 def surrogate_annotations(docs: List[Document], seed=42, errors='raise') -> List[Document]:
+    """Replaces PHI annotations in documents with random surrogates.
+
+    Parameters
+    ----------
+    seed : int
+        Set this seed to make the random generation deterministic.
+    errors : str {'ignore', 'raise', 'coerce'}, default 'raise'
+        - If 'raise', then errors during surrogate generation will raise an exception.
+        - If 'ignore', then failing annotations are skipped (they and PHI remains in text)
+        - If 'coerce', then failing annotations are replaced with a placeholder of form `[annotation.tag]`
+
+    Returns
+    -------
+    List[Document]
+        A copy of `docs` with with text and annotations rewritten to their surrogates.
+
+        If errors is 'ignore' or 'coerce', an extra property of type List is added to the returned documents (`Document.annotations_without_surrogates`), which includes annotations of the *input document* that could not be replaced with a surrogate.
+
+    """
     random_data = RandomData(seed=seed)
     dataset_deidentifier = DatasetDeidentifier(random_data=random_data)
 

--- a/tests/surrogates/test_rewrite_dataset.py
+++ b/tests/surrogates/test_rewrite_dataset.py
@@ -51,7 +51,7 @@ def test_apply_surrogates_errors_raise():
         rewrite_dataset.apply_surrogates(text, annotations, surrogates, errors='raise')
 
 
-def test_apply_surrogates_errors_skip():
+def test_apply_surrogates_errors_ignore():
     text = 'ccc cc ccc'
     annotations = [
         Annotation('ccc', start=0, end=3, tag='A'),
@@ -60,7 +60,7 @@ def test_apply_surrogates_errors_skip():
     ]
     surrogates = ['a', None, 'b']
 
-    surrogate_doc = rewrite_dataset.apply_surrogates(text, annotations, surrogates, errors='skip')
+    surrogate_doc = rewrite_dataset.apply_surrogates(text, annotations, surrogates, errors='ignore')
     assert surrogate_doc.text == 'a cc b'
     assert surrogate_doc.annotations == [
         Annotation('a', start=0, end=1, tag='A'),

--- a/tests/surrogates/test_rewrite_dataset.py
+++ b/tests/surrogates/test_rewrite_dataset.py
@@ -18,10 +18,9 @@ def test_apply_surrogates():
 
     surrogates = ['a', 'dd', 'bbbbb']
 
-    result = rewrite_dataset.apply_surrogates(text, annotations, surrogates)
-    text_rewritten, adjusted_annotations = result
-    assert text_rewritten == 'a dd ccc c c bbbbb cccccc cccc'
-    assert adjusted_annotations == [
+    surrogate_doc = rewrite_dataset.apply_surrogates(text, annotations, surrogates)
+    assert surrogate_doc.text == 'a dd ccc c c bbbbb cccccc cccc'
+    assert surrogate_doc.annotations == [
         Annotation('a', start=0, end=1, tag='A'),
         Annotation('dd', start=2, end=4, tag='A'),
         Annotation('bbbbb', start=13, end=18, tag='B')
@@ -29,10 +28,9 @@ def test_apply_surrogates():
 
 
 def test_apply_surrogates_no_annotations():
-    result = rewrite_dataset.apply_surrogates('ccc cc ccc', annotations=[], surrogates=[])
-    text_rewritten, adjusted_annotations = result
-    assert text_rewritten == 'ccc cc ccc'
-    assert adjusted_annotations == []
+    surrogate_doc = rewrite_dataset.apply_surrogates('ccc cc ccc', annotations=[], surrogates=[])
+    assert surrogate_doc.text == 'ccc cc ccc'
+    assert surrogate_doc.annotations == []
 
 
 def test_main(tmpdir):

--- a/tests/surrogates/test_rewrite_dataset.py
+++ b/tests/surrogates/test_rewrite_dataset.py
@@ -8,7 +8,7 @@ from deidentify.base import Annotation
 from deidentify.surrogates import rewrite_dataset
 
 
-def test_rewrite_text():
+def test_apply_surrogates():
     text = 'ccc cc ccc c c ccc cccccc cccc'
     annotations = [
         Annotation('ccc', start=0, end=3, tag='A'),
@@ -28,7 +28,7 @@ def test_rewrite_text():
     ]
 
 
-def test_rewrite_text_no_annotations():
+def test_apply_surrogates_no_annotations():
     result = rewrite_dataset.apply_surrogates('ccc cc ccc', annotations=[], surrogates=[])
     text_rewritten, adjusted_annotations = result
     assert text_rewritten == 'ccc cc ccc'

--- a/tests/util/test_replace_phi.py
+++ b/tests/util/test_replace_phi.py
@@ -38,6 +38,7 @@ def test_surrogate_annotations():
 
     assert len(surrogate_doc.annotations) == len(doc.annotations)
     assert re.match(r'De patient .* \(e: .*, t: .*\)', doc.text)
+    assert not surrogate_doc.annotations_without_surrogates
 
     for ann in surrogate_doc.annotations:
         assert surrogate_doc.text[ann.start:ann.end] == ann.text

--- a/tests/util/test_replace_phi.py
+++ b/tests/util/test_replace_phi.py
@@ -56,7 +56,7 @@ def test_surrogate_annotations_errors_raise():
         _ = list(surrogate_annotations([doc]))[0]
 
 
-def test_surrogate_annotations_errors_skip():
+def test_surrogate_annotations_errors_ignore():
     original_doc = Document(
         name='test_doc',
         text='This document was written on INVALID_DATE.',
@@ -65,7 +65,8 @@ def test_surrogate_annotations_errors_skip():
         ]
     )
 
-    surrogate_doc = list(surrogate_annotations([original_doc], errors='skip'))[0]
+    gen = surrogate_annotations([original_doc], errors='ignore')
+    surrogate_doc = list(gen)[0]
     assert surrogate_doc.text == original_doc.text
     assert surrogate_doc.annotations == original_doc.annotations
     assert surrogate_doc.annotations_without_surrogates == original_doc.annotations
@@ -80,7 +81,8 @@ def test_surrogate_annotations_errors_coerce():
         ]
     )
 
-    surrogate_doc = list(surrogate_annotations([original_doc], errors='coerce'))[0]
+    gen = surrogate_annotations([original_doc], errors='coerce')
+    surrogate_doc = list(gen)[0]
     assert surrogate_doc.text == 'This document was written on [Date].'
     assert surrogate_doc.annotations == [
         Annotation(text='[Date]', start=29, end=35, tag='Date', doc_id='', ann_id='T0')


### PR DESCRIPTION
For some annotations, we cannot generate surrogates (e.g., invalid dates). Previously `deidentify.util.replace_phi.apply_surrogates` would raise an exception in these cases.

This PR makes the error handling configurable. See `deidentify/util/replace_phi.py` for the configuration options and `tests/util/test_replace_phi.py` for a usage example.

