### PR TITLE
Expand scope of error handling in date parsing

### DIFF
--- a/deidentify/surrogates/generators/date.py
+++ b/deidentify/surrogates/generators/date.py
@@ -199,10 +199,9 @@ class DateSurrogates(SurrogateGenerator):
                 replaced.append(None)
                 continue
 
-            adjusted = adjust_long_date_span(date, most_recent=most_recent, max_delta=89)
-            delta = relativedelta(days=self.day_shift, years=self.year_shift)
-
             try:
+                adjusted = adjust_long_date_span(date, most_recent=most_recent, max_delta=89)
+                delta = relativedelta(days=self.day_shift, years=self.year_shift)
                 shifted_date = shift_date(adjusted, delta)
                 replaced.append(shifted_date.date_string)
             except ValueError:

--- a/deidentify/surrogates/generators/date.py
+++ b/deidentify/surrogates/generators/date.py
@@ -171,7 +171,10 @@ class DateSurrogates(SurrogateGenerator):
         for date in dates:
             try:
                 parsed.append(infer_format(date))
-            except (ValueError, re.error):
+            except (ValueError, re.error, NotImplementedError):
+                # NotImplementedError is raised because of a bug in pydateinfer.
+                # WeekdayLong does not implement the abstract `is_numerical` method.
+                # See: https://github.com/dimagalat/dateinfer/blob/8d34303a94597fa9e560dfa564a4d5f74f3cab76/pydateinfer/date_elements.py#L255
                 dates_failed.append(date)
                 parsed.append(NullDate())
 

--- a/deidentify/surrogates/generators/date.py
+++ b/deidentify/surrogates/generators/date.py
@@ -124,7 +124,9 @@ def shift_date(date, delta):
 
 
 def adjust_long_date_span(date, most_recent, max_delta):
-    if relativedelta(most_recent.datetime, date.datetime).years > max_delta:
+    dt_a = most_recent.datetime.replace(tzinfo=None)
+    dt_b = date.datetime.replace(tzinfo=None)
+    if relativedelta(dt_a, dt_b).years > max_delta:
         span = year_span(date, most_recent)
         delta = relativedelta(years=span - max_delta)
         return shift_date(date, delta)

--- a/tests/surrogates/generators/test_date.py
+++ b/tests/surrogates/generators/test_date.py
@@ -18,7 +18,9 @@ def test_infer_format():
     assert infer_format('01 01 2015').format == '%d %m %Y'
     assert infer_format('22/05/13').format == '%d/%m/%y'
     assert infer_format('0411').format == '%Y'
-
+    # Odd edge case which results into a parsing including timezone information.
+    # This should be handled gracefully.
+    assert infer_format('15-34-2019').format == '%H-%M%z'
 
 
 def test_infer_format_multiple_languages():
@@ -139,6 +141,12 @@ def test_adjust_long_date_span():
     for given, expected in zip(dates_given, dates_expected):
         shifted = adjust_long_date_span(given, most_recent=most_recent, max_delta=90)
         assert shifted == expected
+
+
+def test_adjust_long_date_span_disregard_timezones():
+    dt_aware = Date('15-34-2019', '%H-%M%z')
+    dt_unaware = Date('ma', '%a', date_locale='nl_NL.UTF-8')
+    assert adjust_long_date_span(dt_unaware, most_recent=dt_aware, max_delta=90) == dt_unaware
 
 
 def test_adjust_long_date_span_preserves_locale():


### PR DESCRIPTION
This should make the date parsing more robust. It handles two extra cases:
1. An issue in py-dateinfer: `WeekdayLong` does not correctly implement the `DateElement` abstract class and therefore raises a `NotImplementedError`
2. `shift_date` misbehaves depending on the platform (see #35). The try/catch had to be extended.