### PR TITLE
Add fine-tuning and embedding language flags

### DIFF
--- a/deidentify/methods/bilstmcrf/run_bilstmcrf.py
+++ b/deidentify/methods/bilstmcrf/run_bilstmcrf.py
@@ -5,14 +5,15 @@ from os.path import join
 from typing import List
 
 import flair.data
-from flair.embeddings import (FlairEmbeddings, PooledFlairEmbeddings, StackedEmbeddings,
-                              TokenEmbeddings, WordEmbeddings)
+from flair.embeddings import (FlairEmbeddings, PooledFlairEmbeddings,
+                              StackedEmbeddings, TokenEmbeddings,
+                              WordEmbeddings)
 from flair.models import SequenceTagger
 from flair.trainers import ModelTrainer
 from loguru import logger
 
-from deidentify.methods import train_utils
 from deidentify.dataset.corpus_loader import CORPUS_PATH, CorpusLoader
+from deidentify.methods import train_utils
 from deidentify.methods.bilstmcrf import flair_utils
 from deidentify.tokenizer import TokenizerFactory
 
@@ -37,10 +38,12 @@ def make_predictions(tagger, filtered_corpus: flair_utils.FilteredCorpus):
     _predict_ignored(filtered_corpus.test_ignored)
 
 
-def get_embeddings(corpus_name: str, lang:str, pooled: bool,
+def get_embeddings(corpus_name: str,
+                   language: str,
+                   pooled: bool,
                    contextual_forward_path: str = None,
                    contextual_backward_path: str = None) -> List[TokenEmbeddings]:
-    if corpus_name.startswith('ons') or lang=='nl':
+    if corpus_name.startswith('ons') or language == 'nl':
         logger.info('Use Dutch embeddings')
         word_embeddings = 'nl'
         contextual_forward = 'nl-forward'
@@ -74,7 +77,7 @@ def get_embeddings(corpus_name: str, lang:str, pooled: bool,
 
 def get_model(corpus: flair.data.Corpus,
               corpus_name: str,
-              lang: str,
+              embedding_lang: str,
               pooled_contextual_embeddings: bool,
               contextual_forward_path: str = None,
               contextual_backward_path: str = None):
@@ -83,7 +86,7 @@ def get_model(corpus: flair.data.Corpus,
 
     embedding_types: List[TokenEmbeddings] = get_embeddings(
         corpus_name=corpus_name,
-        lang = lang,
+        language=embedding_lang,
         pooled=pooled_contextual_embeddings,
         contextual_forward_path=contextual_forward_path,
         contextual_backward_path=contextual_backward_path
@@ -119,22 +122,20 @@ def main(args):
                                               ignore_sentence=_ignore_sentence)
     logger.info(flair_corpus)
 
-    if not args.model_file:
-        if args.continue_training:
-        # load existing model and fine-tune on new data with given params
-            logger.info('Load existing model from {}'.format(args.continue_training))
-            tagger = SequenceTagger.load(args.continue_training)
-            logger.info('Fine-tune model ...')
-        else:
-        # train model from scratch
-            logger.info('Train model...')
-            tagger = get_model(flair_corpus,
-                               corpus_name=args.corpus,
-                               lang=args.corpus_lang,
-                               pooled_contextual_embeddings=args.pooled_contextual_embeddings,
-                               contextual_forward_path=args.contextual_forward_path,
-                               contextual_backward_path=args.contextual_backward_path)
+    if args.model_file:
+        logger.info('Load existing model from {}'.format(args.model_file))
+        tagger = SequenceTagger.load(args.model_file)
+    else:
+        tagger = get_model(
+            flair_corpus,
+            corpus_name=args.corpus,
+            embedding_lang=args.embedding_lang,
+            pooled_contextual_embeddings=args.pooled_contextual_embeddings,
+            contextual_forward_path=args.contextual_forward_path,
+            contextual_backward_path=args.contextual_backward_path
+        )
 
+    if args.fine_tune or not args.model_file:
         trainer = ModelTrainer(tagger, flair_corpus)
         trainer.train(join(model_dir, 'flair'),
                       max_epochs=150,
@@ -149,17 +150,14 @@ def main(args):
             # Training is stopped if train loss converges - here, we do not have a "best model" and
             # use the final model to make predictions.
             pass
-    else:
-        logger.info('Load existing model from {}'.format(args.model_file))
-        tagger = SequenceTagger.load(args.model_file)
 
     logger.info('Make predictions...')
     make_predictions(tagger, flair_corpus)
 
     train_utils.save_predictions(corpus_name=corpus.name, run_id=args.run_id,
-                                train=flair_utils.flair_sents_to_standoff(train_sents, train_docs),
-                                dev=flair_utils.flair_sents_to_standoff(dev_sents, dev_docs),
-                                test=flair_utils.flair_sents_to_standoff(test_sents, test_docs))
+                                 train=flair_utils.flair_sents_to_standoff(train_sents, train_docs),
+                                 dev=flair_utils.flair_sents_to_standoff(dev_sents, dev_docs),
+                                 test=flair_utils.flair_sents_to_standoff(test_sents, test_docs))
 
 
 def arg_parser():
@@ -176,11 +174,12 @@ def arg_parser():
                         help="Path to contextual string embeddings (forward)")
     parser.add_argument("--contextual_backward_path",
                         help="Path to contextual string embeddings (backward)")
-    parser.add_argument("--corpus_lang",
-                        choices = ['en','nl'],
+    parser.add_argument("--embedding_lang",
+                        choices=['en', 'nl'],
                         help="Specify language of embeddings.")
-    parser.add_argument("--continue_training",
-                       help="Path to pretrained model to fine-tune.")
+    parser.add_argument("--fine_tune",
+                        help="Fine tune an existing model (has to be passed with --model_file)",
+                        action='store_true')
     return parser.parse_args()
 
 

--- a/deidentify/methods/bilstmcrf/run_bilstmcrf.py
+++ b/deidentify/methods/bilstmcrf/run_bilstmcrf.py
@@ -126,6 +126,7 @@ def main(args):
         logger.info('Load existing model from {}'.format(args.model_file))
         tagger = SequenceTagger.load(args.model_file)
     else:
+        logger.info('Train model...')
         tagger = get_model(
             flair_corpus,
             corpus_name=args.corpus,

--- a/deidentify/methods/bilstmcrf/run_bilstmcrf_training_sample.py
+++ b/deidentify/methods/bilstmcrf/run_bilstmcrf_training_sample.py
@@ -51,7 +51,7 @@ def main(args, model_dir):
     logger.info('Train model...')
     tagger = run_bilstmcrf.get_model(flair_corpus,
                                      corpus_name=args.corpus,
-                                     lang=args.corpus_lang,
+                                     embedding_lang=args.embedding_lang,
                                      pooled_contextual_embeddings=True)
 
     trainer = ModelTrainer(tagger, flair_corpus)
@@ -91,7 +91,7 @@ def arg_parser():
     parser.add_argument("--save_final_model",
                         help="If passed, the final model is saved.",
                         action='store_true')
-    parser.add_argument("--corpus_lang",
+    parser.add_argument("--embedding_lang",
                 choices = ['en','nl'],
                 help="Specify language of embeddings.")
     return parser.parse_args()

--- a/deidentify/methods/bilstmcrf/run_bilstmcrf_training_sample.py
+++ b/deidentify/methods/bilstmcrf/run_bilstmcrf_training_sample.py
@@ -51,6 +51,7 @@ def main(args, model_dir):
     logger.info('Train model...')
     tagger = run_bilstmcrf.get_model(flair_corpus,
                                      corpus_name=args.corpus,
+                                     lang=args.corpus_lang,
                                      pooled_contextual_embeddings=True)
 
     trainer = ModelTrainer(tagger, flair_corpus)
@@ -90,6 +91,9 @@ def arg_parser():
     parser.add_argument("--save_final_model",
                         help="If passed, the final model is saved.",
                         action='store_true')
+    parser.add_argument("--corpus_lang",
+                choices = ['en','nl'],
+                help="Specify language of embeddings.")
     return parser.parse_args()
 
 


### PR DESCRIPTION
1) added option to set embedding language to Dutch even if not using ons as corpus
2) bilstmcrf_run.py also has option to continue training with existing model (but maybe it's better to re-use '--model_file' + bool '--continue_training'?)