### PR TITLE
Return dict for ignored sents in crf.predict_marginals

### DIFF
--- a/deidentify/methods/crf/crf_labeler.py
+++ b/deidentify/methods/crf/crf_labeler.py
@@ -172,7 +172,9 @@ class SentenceFilterCRF(sklearn_crfsuite.CRF):
 
     def predict_marginals_single(self, xseq):
         if self.ignore_sentence(xseq):
-            return [1] * len(xseq)
+            ignored_marginals = {c: 0 for c in self.classes_}
+            ignored_marginals[self.ignored_label] = 1
+            return [ignored_marginals] * len(xseq)
 
         return super().predict_marginals_single(xseq)
 

--- a/tests/methods/test_crf_labeler.py
+++ b/tests/methods/test_crf_labeler.py
@@ -64,9 +64,6 @@ def test_liu_feature_extractor():
         Token(text=')', pos_tag='PUNCT', label='O', ner_tag=None),
     ]
 
-    # from pprint import pprint
-    # pprint(liu_feature_extractor(sentence, 2))
-
     assert liu_feature_extractor(sentence, 2) == {
         'bow[-2:2].uni.0': 'de',
         'bow[-2:2].uni.1': 'patient',
@@ -161,7 +158,3 @@ def test_crf_labeler_marginals():
     assert y_pred[0] == [ignored_marginals] * 4
     # Second sentence should have non-zero marginals for the other classes
     assert y_pred[1] != [ignored_marginals] * 3
-
-
-if __name__ == '__main__':
-    test_liu_feature_extractor()


### PR DESCRIPTION
This is to match the API of sklearn CRF suite: [link implementation](https://github.com/TeamHG-Memex/sklearn-crfsuite/blob/293a2d00f9c8f2031dc093cd549d734c3b72cf47/sklearn_crfsuite/estimator.py#L369-L384).