### PR TITLE
Handle invalid model names in model lookup

### DIFF
--- a/deidentify/taggers/base.py
+++ b/deidentify/taggers/base.py
@@ -35,7 +35,7 @@ def cached_model_file(model: str) -> Path:
     Path
         The path to the pickle/pt file corresponding to the model name.
     """
-    model_path = None
+    model_path = Path(model)
 
     if model.startswith('model_bilstmcrf_'):
         model_path = Path(deidentify.cache_root, model, 'final-model.pt')

--- a/deidentify/util/download_model.py
+++ b/deidentify/util/download_model.py
@@ -55,10 +55,12 @@ def download_file(url: str, cache_dir: str):
     finally:
         os.remove(temp_filename)
 
-    logger.info("Extracting {}", cache_archive_path)
-    with tarfile.open(cache_archive_path, "r:gz") as tar:
-        tar.extractall(cache_dir)
-    os.remove(cache_archive_path)
+    try:
+        logger.info("Extracting {}", cache_archive_path)
+        with tarfile.open(cache_archive_path, "r:gz") as tar:
+            tar.extractall(cache_dir)
+    finally:
+        os.remove(cache_archive_path)
 
 
 def main(args):

--- a/tests/taggers/test_base.py
+++ b/tests/taggers/test_base.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from deidentify.taggers.base import cached_model_file
+from deidentify.taggers.base import cached_model_file, lookup_model
 
 
 def test_cached_model_file(tmpdir):
@@ -35,3 +35,8 @@ def test_cached_model_file_raises_error_on_missing_model(tmpdir):
         model_dir.join('final-model.pt').write('')
         assert cached_model_file('model_bilstmcrf_a') \
             == Path(tmpdir, 'model_bilstmcrf_a', 'final-model.pt')
+
+
+def test_lookup_model_with_invalid_name():
+    with pytest.raises(ValueError):
+        lookup_model('invalid')

--- a/tests/taggers/test_base.py
+++ b/tests/taggers/test_base.py
@@ -37,6 +37,6 @@ def test_cached_model_file_raises_error_on_missing_model(tmpdir):
             == Path(tmpdir, 'model_bilstmcrf_a', 'final-model.pt')
 
 
-def test_lookup_model_with_invalid_name():
+def test_lookup_model_with_invalid_name_raises_value_error():
     with pytest.raises(ValueError):
         lookup_model('invalid')


### PR DESCRIPTION
This PR makes sure that we always raise a ValueError when trying to lookup a model name that does not exist. 

Furthermore, we cleanup after the download script, if extraction of the tar file failed (in a `finally` block).