### PR TITLE
Remove obsolete conditional in CRF tagger

### DIFF
--- a/deidentify/taggers/crf_tagger.py
+++ b/deidentify/taggers/crf_tagger.py
@@ -42,10 +42,7 @@ class CRFTagger(TextTagger):
 
         targets = set()
         for target in bio_tag_names:
-            if target == 'O':
-                targets.add('O')
-            else:
-                name = target.split('-', maxsplit=1)[1]
-                targets.add(name)
+            name = target.split('-', maxsplit=1)[1]
+            targets.add(name)
 
         return list(targets)


### PR DESCRIPTION
This PR is a minor refactoring. We already remove the O tag a few lines above, so this conditional will never evaluate True