### PR TITLE
Add spacy 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Create a new virtual environment with an environment manager of your choice. The
 pip install deidentify
 ```
 
-We use the spaCy tokenizer. For good compatibility with the pre-trained models, we recommend using the same version that we used to train the de-identification models.
+We use the spaCy tokenizer. For good compatibility with the pre-trained models, we recommend using the same spaCy version that we used to train the de-identification models.
 
 ```sh
-pip install https://github.com/explosion/spacy-models/releases/download/nl_core_news_sm-2.3.0/nl_core_news_sm-2.3.0.tar.gz#egg=nl_core_news_sm==2.3.0
+pip install -U "spacy<3" https://github.com/explosion/spacy-models/releases/download/nl_core_news_sm-2.3.0/nl_core_news_sm-2.3.0.tar.gz#egg=nl_core_news_sm==2.3.0
 ```
 
 ### Example Usage

--- a/deidentify/evaluation/evaluator.py
+++ b/deidentify/evaluation/evaluator.py
@@ -5,7 +5,12 @@ from typing import List
 import numpy as np
 from loguru import logger
 from sklearn.metrics import confusion_matrix
-from spacy.gold import biluo_tags_from_offsets
+
+try:
+    from spacy.gold import biluo_tags_from_offsets
+except ModuleNotFoundError:
+    # spacy>=3
+    from spacy.training.iob_utils import biluo_tags_from_offsets
 
 from deidentify.base import Document
 from deidentify.evaluation.metric import Metric
@@ -125,7 +130,7 @@ class Evaluator:
                 # https://spacy.io/api/goldparse#biluo_tags_from_offsets
                 tags.append('O')
                 warnings.warn(
-                    'Some entities could not be aligned in the text. Use `spacy.gold.biluo_tags_from_offsets(nlp.make_doc(text), entities)` to check the alignment.',
+                    'Some entities could not be aligned in the text. Use `spacy.training.iob_utils.biluo_tags_from_offsets(nlp.make_doc(text), entities)` to check the alignment.',
                     UserWarning
                 )
             elif tag_blind:

--- a/deidentify/methods/tagging_utils.py
+++ b/deidentify/methods/tagging_utils.py
@@ -6,7 +6,13 @@ from typing import List, Tuple
 
 import spacy
 from loguru import logger
-from spacy.gold import biluo_tags_from_offsets, offsets_from_biluo_tags
+
+try:
+    from spacy.gold import biluo_tags_from_offsets, offsets_from_biluo_tags
+except ModuleNotFoundError:
+    # spacy>=3
+    from spacy.training.iob_utils import biluo_tags_from_offsets, offsets_from_biluo_tags
+
 from tqdm import tqdm
 
 from deidentify.base import Annotation, Document

--- a/deidentify/tokenizer/tokenizer_ons.py
+++ b/deidentify/tokenizer/tokenizer_ons.py
@@ -68,7 +68,13 @@ def _metadata_sentence_segmentation(doc):
 
 
 NLP = spacy.load('nl_core_news_sm')
-NLP.add_pipe(_metadata_sentence_segmentation, before="parser")  # Insert before the parser
+try:
+    NLP.add_pipe(_metadata_sentence_segmentation, before="parser")  # Insert before the parser
+except ValueError:
+    # spacy>=3
+    from spacy.language import Language
+    Language.component('meta-sentence-segmentation')(_metadata_sentence_segmentation)
+    NLP.add_pipe('meta-sentence-segmentation', before="parser")  # Insert before the parser
 
 for case in TOKENIZER_SPECIAL_CASES:
     NLP.tokenizer.add_special_case(case, [{ORTH: case}])
@@ -109,7 +115,7 @@ class TokenizerOns(Tokenizer):
             {"ORTH": "="}, {"ORTH": "="}, {"ORTH": "="},
             {"ORTH": "\n"}
         ]
-        matcher.add("METADATA", None, pattern)
+        matcher.add("METADATA", [pattern])
 
         doc = NLP(text, disable=self.disable)
         matches = matcher(doc)

--- a/deidentify/tokenizer/tokenizer_ons.py
+++ b/deidentify/tokenizer/tokenizer_ons.py
@@ -73,7 +73,7 @@ try:
 except ValueError:
     # spacy>=3
     from spacy.language import Language
-    Language.component('meta-sentence-segmentation')(_metadata_sentence_segmentation)
+    Language.component('meta-sentence-segmentation')(_metadata_sentence_segmentation) # pylint: disable=E1101
     NLP.add_pipe('meta-sentence-segmentation', before="parser")  # Insert before the parser
 
 for case in TOKENIZER_SPECIAL_CASES:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 known_first_party=deidentify
 
 [pylint.TYPECHECK]
-ignored-modules=spacy.symbols, spacy.gold, spacy.matcher, spacy.tokens.doc
+ignored-modules=spacy.symbols, spacy.gold, spacy.training, spacy.matcher, spacy.tokens.doc
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
This code adds compatibility for the latest spaCy 3 release. Closes #51.

Note: while the code fully supports spaCy 3, and most tests pass, the Dutch models were pre-trained on an older version of spaCy. So minor differences in tokenization may decrease model performance.