### PR TITLE
Add Python 3.9 tests to CI pipeline

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -56,19 +56,26 @@ blocks:
           commands:
             - sem-version python 3.6
             - pip install -e . --progress-bar off
-            - pip install https://github.com/explosion/spacy-models/releases/download/nl_core_news_sm-2.3.0/nl_core_news_sm-2.3.0.tar.gz#egg=nl_core_news_sm==2.3.0
+            - python -m spacy download nl_core_news_sm
             - python demo.py
 
         - name: Python 3.7
           commands:
             - sem-version python 3.7
             - pip install -e . --progress-bar off
-            - pip install https://github.com/explosion/spacy-models/releases/download/nl_core_news_sm-2.3.0/nl_core_news_sm-2.3.0.tar.gz#egg=nl_core_news_sm==2.3.0
+            - python -m spacy download nl_core_news_sm
             - python demo.py
 
         - name: Python 3.8
           commands:
             - sem-version python 3.8
             - pip install -e . --progress-bar off
-            - pip install https://github.com/explosion/spacy-models/releases/download/nl_core_news_sm-2.3.0/nl_core_news_sm-2.3.0.tar.gz#egg=nl_core_news_sm==2.3.0
+            - python -m spacy download nl_core_news_sm
+            - python demo.py
+
+        - name: Python 3.9
+          commands:
+            - sem-version python 3.9
+            - pip install -e . --progress-bar off
+            - python -m spacy download nl_core_news_sm
             - python demo.py


### PR DESCRIPTION
Tests that `deidentify` installs and runs fine on Python 3.9 with pip 21.0.1