### PR TITLE
Add language parameter to evaluate_corpus

### DIFF
--- a/deidentify/evaluation/evaluate_corpus.py
+++ b/deidentify/evaluation/evaluate_corpus.py
@@ -13,17 +13,11 @@ import pandas as pd
 from loguru import logger
 
 from deidentify.evaluation.evaluate_run import evaluate
+from deidentify.evaluation.evaluator import Evaluator
 
 PREDICTIONS_PATH = join(dirname(__file__), '../../output/predictions/')
 OUTPUT_PATH = join(dirname(__file__), '../../output/evaluation')
 CORPUS_PATH = join(dirname(__file__), '../../data/corpus/')
-
-
-def _language_for_corpus(corpus: str):
-    if corpus.startswith('ons'):
-        return 'nl'
-
-    return 'en'
 
 
 def main(args):
@@ -46,7 +40,7 @@ def main(args):
             evaluator = evaluate(documents_path=corpus_path,
                                  gold_path=corpus_path,
                                  pred_path=join(run, part),
-                                 language=_language_for_corpus(args.corpus))
+                                 language=args.language)
 
             entity = evaluator.entity_level()
             token = evaluator.token_level()
@@ -99,6 +93,8 @@ def main(args):
 def arg_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("corpus", help="Name of corpus (e.g., 'dummy', 'ons')", type=str)
+    parser.add_argument("language", help="Language to use for tokenizer",
+                        choices=Evaluator.supported_languages())
     return parser.parse_args()
 
 

--- a/docs/02_train_evaluate_models.md
+++ b/docs/02_train_evaluate_models.md
@@ -94,7 +94,7 @@ ENT                 	tp: 5016  - fp: 187   - fn: 379   - tn: 115532 - precision:
 You can use the `evaluate_corpus.py` script to evaluate all runs for a given corpus. The script produces a CSV file with the evaluation measures for each corpus part (i.e., train/dev/test) that you can use this for further analysis.
 
 ```sh
-> python deidentify/evaluation/evaluate_corpus.py <corpus_name>
+> python deidentify/evaluation/evaluate_corpus.py <corpus_name> <language>
 [...]
 > tree output/evaluation/<corpus_name>
 output/evaluation/<corpus_name>


### PR DESCRIPTION
This PR aligns the command line arguments of `evaluate_corpus.py` with the `evaluate_run.py` arguments.