### PR TITLE
Pin pylint version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pylint
+pylint==2.8.3
 pytest
 pytest-cov
 autopep8


### PR DESCRIPTION
The newest pylint raises a false-positives for many pandas related statements. Therefore, this PR downgrades to a lower pylint version