### PR TITLE
Add GHA SBOM

### DIFF
--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -1,7 +1,7 @@
 name: Dependencies
 on:
   push:
-    branches: [master]
+    branches: [master,generate_sbom]
 
 jobs:
   generate-sboms:

--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -1,0 +1,27 @@
+name: Dependencies
+on:
+  push:
+    branches: [master]
+
+jobs:
+  generate-sboms:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nedap/gha-generate-python-sbom@v1
+        with:
+          format: conda
+          project-path: environment.yml
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sboms
+          path: .sboms
+
+  upload-sboms:
+    needs: generate-sboms
+    runs-on: self-hosted
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: nedap/gha-upload-sboms@v6


### PR DESCRIPTION
Add [Python SBOM](https://github.com/nedap/gha-generate-python-sbom) to generate a Software Bill of Materials.

* The action will only be discovered on main/master branch, so it will only start after it has been merged. 
* Before merging, check if a self-hosted runner is added.
* Feel free to close this issue if not needed. 

For more information, see the [Python SBOM issue](https://github.com/nedap/gha-generate-python-sbom/issues/2).