### PR TITLE
Use deduce <2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setuptools.setup(
         'torch>=1.1.0',
         'spacy>=2.2.1,<3',
         'tqdm>=4.29',
-        'deduce>=1.0.2',
+        'deduce>=1.0.2,<2',
         'loguru>=0.2.5',
         'sklearn-crfsuite>=0.3.6',
         'unidecode>=1.0.23',


### PR DESCRIPTION
Hi, I just released deduce 2.0.0 which has breaking changes, also breaking deidentify it seems. For now I fixed it by pinning <2 in the requirements. 

Is this project still actively maintained? Deduce 2.0 supports structured annotations now, we could incorporate it here and probably deprecated some of the wrapper code. I intend to make more changes to the rule-based logic in future releases as well. Lemme know! -Vincent